### PR TITLE
Implement new FF lamp command

### DIFF
--- a/python/tcc/actor/tccLCOActor.py
+++ b/python/tcc/actor/tccLCOActor.py
@@ -76,6 +76,7 @@ class TCCStatus(object):
             "TAI",
             "UTC_TAI",
             "axisErr",
+            "screenPos"
         ]
         self.kwDict = {}
         for kw in self.tccKWs:

--- a/python/tcc/actor/tccLCOActor.py
+++ b/python/tcc/actor/tccLCOActor.py
@@ -76,7 +76,8 @@ class TCCStatus(object):
             "TAI",
             "UTC_TAI",
             "axisErr",
-            "screenPos"
+            "screenPos",
+            "ffLamp"
         ]
         self.kwDict = {}
         for kw in self.tccKWs:

--- a/python/tcc/actor/tccLCOCmdParser.py
+++ b/python/tcc/actor/tccLCOCmdParser.py
@@ -5,7 +5,7 @@ from ..parse.cmdParse import CmdParser
 from ..parse import parseDefs
 from ..cmd import setFocus, showFocus, showStatus, \
                    showVersion, offset, device, ping, sec, target, \
-                   collimate, guiderot, help, guideoffset, lamp, showTime
+                   collimate, guiderot, help, guideoffset, lamp, showTime, ff
 
 __all__ = ["TCCLCOCmdParser"]
 
@@ -304,10 +304,26 @@ TCCLCOCmdList = (
         callFunc = help,
         minParAmt = 0,
     ),
+    # parseDefs.Command(
+    #     name = "lamp",
+    #     help = "turn ff lamp on or off.",
+    #     callFunc = lamp,
+    #     minParAmt = 1,
+    #     paramList = [
+    #         parseDefs.KeywordParam(
+    #             name = 'action',
+    #             keywordDefList = [
+    #                 parseDefs.Keyword(name = "on", help = "turn lamp on"),
+    #                 parseDefs.Keyword(name = "off", help = "turn lamp off"),
+    #                 parseDefs.Keyword(name = "status", help = "get lamp status"),
+    #             ],
+    #         )
+    #     ],
+    # ),
     parseDefs.Command(
-        name = "lamp",
+        name = "ff",
         help = "turn ff lamp on or off.",
-        callFunc = lamp,
+        callFunc = ff,
         minParAmt = 1,
         paramList = [
             parseDefs.KeywordParam(

--- a/python/tcc/cmd/__init__.py
+++ b/python/tcc/cmd/__init__.py
@@ -10,6 +10,7 @@ from .showFocus import *
 from .offset import *
 from .device import *
 from .sec import *
+from .ff import *
 from .showStatus import *
 from .showVersion import *
 from .collimate import *

--- a/python/tcc/cmd/ff.py
+++ b/python/tcc/cmd/ff.py
@@ -1,0 +1,19 @@
+from __future__ import division, absolute_import
+
+__all__ = ["ff"]
+
+def ff(tccActor, userCmd):
+    """Controls the FF lamp via de TCS
+
+    @param[in,out] tccActor  tcc actor
+
+    @param[in,out] userCmd  a twistedActor BaseCommand with parseCmd attribute
+    """
+    params = userCmd.parsedCmd.paramDict
+    action = params["action"].valueList[0].keyword
+    if action == "off":
+        tccActor.tcsDev.ffOff(userCmd)
+    elif action == "on":
+        tccActor.tcsDev.ffOn(userCmd)
+    else:
+        tccActor.tcsDev.getStatus(userCmd)

--- a/python/tcc/cmd/ff.py
+++ b/python/tcc/cmd/ff.py
@@ -12,8 +12,8 @@ def ff(tccActor, userCmd):
     params = userCmd.parsedCmd.paramDict
     action = params["action"].valueList[0].keyword
     if action == "off":
-        tccActor.tcsDev.ffOff(userCmd)
+        tccActor.tcsDev.handleFFLamp(False, userCmd)
     elif action == "on":
-        tccActor.tcsDev.ffOn(userCmd)
+        tccActor.tcsDev.handleFFLamp(True, userCmd)
     else:
         tccActor.tcsDev.getStatus(userCmd)

--- a/python/tcc/dev/tcsDevice.py
+++ b/python/tcc/dev/tcsDevice.py
@@ -295,7 +295,7 @@ class Status(object):
 
     def screenPos(self):
         sp = self.statusFieldDict["lplc"].value
-        return "%.2f"%sp
+        return "%.2f"%sp if sp is not None else -999
 
     def axisErr(self):
         rerr = self.statusFieldDict["rerr"].value

--- a/python/tcc/dev/tcsDevice.py
+++ b/python/tcc/dev/tcsDevice.py
@@ -945,11 +945,15 @@ class TCSDevice(TCPDevice):
             userCmd.setState(userCmd.Done, "FF lamp already in desired state")
             return userCmd
 
+        waitFFLampCmd = expandCommand()
+        def finishFFLampTimer():
+            waitFFLampCmd.setState(waitFFLampCmd.Done)
+
         toggleFF = DevCmd(cmdStr="FFLAMPS")
-        userCmd.linkCommands([toggleFF])
+        userCmd.linkCommands([toggleFF, waitFFLampCmd])
 
         self.queueDevCmd(toggleFF)
-        reactor.callLater(3, self.status.updateTCCStatus, userCmd)
+        reactor.callLater(3, finishFFLampTimer)
         return userCmd
 
     def handleReply(self, replyStr):

--- a/python/tcc/dev/tcsDevice.py
+++ b/python/tcc/dev/tcsDevice.py
@@ -288,7 +288,12 @@ class Status(object):
             "tccTemps": self.tccTemps(),
             "airmass": self.airmass(),
             "axisErr": self.axisErr(),
+            "screenPos": self.screenPos()
         }
+
+    def screenPos(self):
+        sp = self.statusFieldDict["lplc"].value
+        return "%.2f"%sp
 
     def axisErr(self):
         rerr = self.statusFieldDict["rerr"].value

--- a/python/tcc/dev/tcsDevice.py
+++ b/python/tcc/dev/tcsDevice.py
@@ -186,8 +186,10 @@ def castRawPos(lcoReply):
     deg = encCounts2Deg(encCounts)
     return deg
 
+
 def castScreenPos(lcoReply):
     try:
+        print("cast screen pos", lcoReply)
         items = lcoReply.split()
         screenPos = items[7].strip()
         return float(screenPos)

--- a/python/tcc/dev/tcsDevice.py
+++ b/python/tcc/dev/tcsDevice.py
@@ -949,7 +949,7 @@ class TCSDevice(TCPDevice):
         userCmd.linkCommands([toggleFF])
 
         self.queueDevCmd(toggleFF)
-        reactor.callLater(1, self.status.updateTCCStatus, userCmd)
+        reactor.callLater(3, self.status.updateTCCStatus, userCmd)
         return userCmd
 
     def handleReply(self, replyStr):

--- a/python/tcc/dev/tcsDevice.py
+++ b/python/tcc/dev/tcsDevice.py
@@ -294,8 +294,6 @@ class Status(object):
 
     def screenPos(self):
         sp = self.statusFieldDict["lplc"].value
-        print("statusFieldDict", self.statusFieldDict)
-        print("sp", sp)
         return "%.2f"%sp
 
     def axisErr(self):

--- a/python/tcc/dev/tcsDevice.py
+++ b/python/tcc/dev/tcsDevice.py
@@ -189,7 +189,7 @@ def castRawPos(lcoReply):
 def castScreenPos(lcoReply):
     try:
         items = lcoReply.split()
-        screenPos = items[6].strip()
+        screenPos = items[7].strip()
         return float(screenPos)
     except:
         print("error parsing lco screen pos: ", screenPos)

--- a/python/tcc/dev/tcsDevice.py
+++ b/python/tcc/dev/tcsDevice.py
@@ -289,7 +289,7 @@ class Status(object):
             "tccTemps": self.tccTemps(),
             "airmass": self.airmass(),
             "axisErr": self.axisErr(),
-            "ffLamps": self.ffLamp(),
+            "ffLamp": self.ffLamp(),
             "screenPos": self.screenPos()
         }
 

--- a/python/tcc/dev/tcsDevice.py
+++ b/python/tcc/dev/tcsDevice.py
@@ -949,7 +949,7 @@ class TCSDevice(TCPDevice):
         userCmd.linkCommands([toggleFF])
 
         self.queueDevCmd(toggleFF)
-        self.status.updateTCCStatus(userCmd)
+        reactor.callLater(1, self.status.updateTCCStatus, userCmd)
         return userCmd
 
     def handleReply(self, replyStr):

--- a/python/tcc/dev/tcsDevice.py
+++ b/python/tcc/dev/tcsDevice.py
@@ -878,7 +878,7 @@ class TCSDevice(TCPDevice):
             newPos = self.status.rotPos - rot
 
         # check that rotator command is within the duPont limits.  if it isn't, fail the command
-        if newPos < 90 or newPos > 270:
+        if newPos < 60 or newPos > 300:
             userCmd.setState(userCmd.Failed, "Rotator command: %.2f out of limits"%newPos)
             return userCmd
         # rotStart = time.time()

--- a/python/tcc/dev/tcsDevice.py
+++ b/python/tcc/dev/tcsDevice.py
@@ -496,6 +496,8 @@ class Status(object):
 
     @property
     def isClamped(self):
+        if not self.statusFieldDict["mrp"].value:
+            return None
         return self.statusFieldDict["mrp"].value['clamp']
 
     @property

--- a/python/tcc/dev/tcsDevice.py
+++ b/python/tcc/dev/tcsDevice.py
@@ -189,7 +189,6 @@ def castRawPos(lcoReply):
 
 def castScreenPos(lcoReply):
     try:
-        print("cast screen pos", lcoReply)
         items = lcoReply.split()
         screenPos = items[7].strip()
         return float(screenPos)
@@ -295,6 +294,8 @@ class Status(object):
 
     def screenPos(self):
         sp = self.statusFieldDict["lplc"].value
+        print("statusFieldDict", self.statusFieldDict)
+        print("sp", sp)
         return "%.2f"%sp
 
     def axisErr(self):

--- a/python/tcc/dev/tcsDevice.py
+++ b/python/tcc/dev/tcsDevice.py
@@ -935,12 +935,12 @@ class TCSDevice(TCPDevice):
             userCmd.setState(userCmd.Failed, "Not Connected to TCS")
             return userCmd
 
-        if (self.statusFieldDict['mrp'].value is None or
-                self.statusFieldDict['mrp'].value['fflamp'] < 0):
+        if (self.status.statusFieldDict['mrp'].value is None or
+                self.status.statusFieldDict['mrp'].value['fflamp'] < 0):
             userCmd.setState(userCmd.Failed, "No MRP status")
             return userCmd
 
-        current = self.statusFieldDict['mrp'].value['fflamp']
+        current = self.status.statusFieldDict['mrp'].value['fflamp']
         if (current == 0 and on is False) or (current == 1 and on is True):
             userCmd.setState(userCmd.Done, "FF lamp already in desired state")
             return userCmd


### PR DESCRIPTION
The new FF lamp relay is implemented as a toggle command in the TCS. `FFLAMPS` toggles the status of the lamps. The eight `MRP` return value is the current status of the lamp.